### PR TITLE
Enable auto merge for dependencies Pull Request

### DIFF
--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -1,0 +1,33 @@
+name: automerge
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - edited
+      - ready_for_review
+      - reopened
+      - unlocked
+  pull_request_review:
+    types:
+      - submitted
+  check_suite:
+    types:
+      - completed
+  status: {}
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: automerge
+        uses: "pascalgn/automerge-action@v0.9.0"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MERGE_LABELS: "dependencies"
+          MERGE_REMOVE_LABELS: "dependencies"
+          MERGE_METHOD: "squash"
+          MERGE_RETRIES: "6"
+          UPDATE_METHOD: "rebase"
+          


### PR DESCRIPTION
It is too troublesome to approve Pull Requests from Dependabot unless build is failed, which rarely happens.

Closes gh-16.