### PR TITLE
Remove JUnit Vintage exclusion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,12 +47,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.junit.vintage</groupId>
-                    <artifactId>junit-vintage-engine</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>


### PR DESCRIPTION
It is no longer necessary as Spring defaulted to JUnit Jupiter.

Closes gh-83.